### PR TITLE
Truncate all tables rather than truncating named ones in test teardown

### DIFF
--- a/src/conduit/scripts/tests/test_populate.py
+++ b/src/conduit/scripts/tests/test_populate.py
@@ -7,6 +7,7 @@ simple testing here.
 from conduit.conftest import AppEnvType
 from conduit.scripts.populate import main
 from conduit.tag.models import Tag
+from pyramid_deferred_sqla import Base
 from sqlalchemy.orm.session import Session
 from unittest import mock
 
@@ -24,10 +25,5 @@ def test_populate(argparse: mock.MagicMock, app_env: AppEnvType, db: Session) ->
     # manual test teardown is needed because main() does db.commit()
     with transaction.manager:
         engine = app_env["registry"].settings["sqlalchemy.engine"]
-        engine.execute("TRUNCATE articles, comments, tags, users CASCADE")
-
-        # TODO: Every time someone adds a table they have to remember to
-        # include it here otherwise they might get errors.UniqueViolation
-        # errors in their test suite. It's probably possible to run an
-        # SQL command that would first fetch all table names, then run
-        # TRUNCATE on them.
+        tables = ", ".join(Base.metadata.tables.keys())
+        engine.execute("TRUNCATE {} CASCADE".format(tables))


### PR DESCRIPTION
The tests truncate all tables in two places, which requires any new table
names to be added to those TRUNCATE commands. This uses Base.metadata to
drop and recreate those tables instead.

Another way of doing this would be to call `Base.metadata.tables.keys()`
to find the names of all tables to be TRUNCATEd, but I think this method
is clearer than running a manual SQL query.