### PR TITLE
Reduce duplication in alembic configuration

### DIFF
--- a/.heroku/release.sh
+++ b/.heroku/release.sh
@@ -3,5 +3,5 @@
 set -e
 
 echo "Running database migrations"
-alembic -c etc/production.ini -n app:conduit upgrade head || echo "Database migrations failed!"
+alembic -x ini=etc/production.ini upgrade head || echo "Database migrations failed!"
 echo "Done"

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ stop-pgsql: .installed
 .PHONY: devdb
 devdb: .installed
 	@pipenv run python -m conduit.scripts.drop_tables
-	@pipenv run alembic -c etc/development.ini -n app:conduit upgrade head
+	@pipenv run alembic -x ini=etc/development.ini upgrade head
 	@pipenv run python -m conduit.scripts.populate
 
 .PHONY: pshell

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,2 @@
+[alembic]
+script_location = conduit:migrations

--- a/etc/development.ini
+++ b/etc/development.ini
@@ -11,9 +11,6 @@ pyramid.debug_routematch = false
 
 sqlalchemy.url = postgresql+psycopg2://conduit_dev@localhost/conduit_dev
 
-# alembic
-script_location = src/conduit/migrations
-
 # secrets
 jwt.secret = secret
 

--- a/etc/production.ini
+++ b/etc/production.ini
@@ -21,10 +21,6 @@ pyramid_force_https.structlog = true
 
 sqlalchemy.url = ${DATABASE_URL}
 
-# TODO: this here shouldn't be necessary, alembic should inherit
-# script_location from development.ini, but it doesn't
-script_location = src/conduit/migrations
-
 # secrets
 jwt.secret = ${JWT_SECRET}
 

--- a/etc/test.ini
+++ b/etc/test.ini
@@ -5,10 +5,6 @@ pipeline =
 [app:conduit]
 use = config:development.ini#conduit
 
-# TODO: this here shouldn't be necessary, alembic should inherit
-# script_location from development.ini, but it doesn't
-script_location = src/conduit/migrations
-
 sqlalchemy.url = postgresql+psycopg2://conduit_test@localhost/conduit_test
 
 [server:main]

--- a/src/conduit/__init__.py
+++ b/src/conduit/__init__.py
@@ -50,7 +50,8 @@ def check_db_migrated(config: Configurator, global_config: t.Dict[str, str]) -> 
         return
 
     # get latest migration file
-    alembic_config = Config(global_config["__file__"], "app:conduit")
+    alembic_config = Config("alembic.ini")
+
     script = ScriptDirectory.from_config(alembic_config)
     head = EnvironmentContext(alembic_config, script).get_head_revision()
 

--- a/src/conduit/__init__.py
+++ b/src/conduit/__init__.py
@@ -70,10 +70,6 @@ def configure(config: Configurator) -> None:
     config.include("pyramid_deferred_sqla")
     config.sqlalchemy_engine(pool_size=5, max_overflow=1, pool_timeout=5)
 
-    # TODO: pyramid_deferred_sqla docs say this is needed, but apparently it
-    # is not?
-    # config.alembic_config("conduit:migrations")
-
     # Configure pyramid_openapi3 integration
     config.include(".openapi")
 

--- a/src/conduit/conftest.py
+++ b/src/conduit/conftest.py
@@ -40,8 +40,7 @@ def app_env(ini_path: str) -> AppEnvType:
     """Initialize WSGI application from INI file given on the command line."""
     env = bootstrap(ini_path, options={"SKIP_CHECK_DB_MIGRATED": "true"})
 
-    # build schema
-    alembic_cfg = Config("etc/test.ini", "app:conduit")
+    alembic_cfg = Config("alembic.ini")
     command.upgrade(alembic_cfg, "head")
     return env
 

--- a/src/conduit/migrations/README.md
+++ b/src/conduit/migrations/README.md
@@ -12,7 +12,7 @@ Prerequisites:
 Start by creating a migration recipe with:
 
 ```shell
-pipenv run alembic -c etc/development.ini -n app:conduit revision --autogenerate -m "message"
+pipenv run alembic -x ini=etc/development.ini revision --autogenerate -m "message"
 ```
 
 The `message` should be descriptive to what recipe does to the db. Avoid short titles, abbreviations, etc:
@@ -33,11 +33,11 @@ Bad:
 Upgrading:
 
 ```shell
-pipenv run alembic -c etc/development.ini -n app:conduit upgrade head
+pipenv run alembic -x ini=etc/development.ini -n app:conduit upgrade head
 ```
 
 Downgrading:
 
 ```shell
-pipenv run alembic -c etc/development.ini -n app:conduit downgrade head
+pipenv run alembic -x ini=etc/development.ini -n app:conduit downgrade head
 ```

--- a/src/conduit/migrations/env.py
+++ b/src/conduit/migrations/env.py
@@ -3,7 +3,6 @@
 from alembic import context
 from pyramid.paster import bootstrap
 from pyramid_deferred_sqla import Base
-from pyramid_heroku import expandvars_dict
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
@@ -14,7 +13,9 @@ config = context.config
 # avoid running pyramid bootstrap twice
 if len(Base.metadata.tables) == 0:
     # Call pyramid to collect all models
-    bootstrap(config.config_file_name)
+    arguments = context.get_x_argument(as_dictionary=True)
+    ini = arguments.get("ini", config.config_file_name)
+    bootstrap(ini)
 
 target_metadata = Base.metadata
 
@@ -43,7 +44,7 @@ def run_migrations_online():
     and associate a connection with the context.
     """
     connectable = engine_from_config(
-        expandvars_dict(config.get_section("app:conduit")),
+        {"sqlalchemy.url": Base.metadata.bind.url},
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
     )

--- a/src/conduit/scripts/tests/test_drop_tables.py
+++ b/src/conduit/scripts/tests/test_drop_tables.py
@@ -33,5 +33,5 @@ def test_drop_tables(argparse: mock.MagicMock, app_env: AppEnvType) -> None:
     assert len(list(tables)) == 0
 
     # re-create the dropped tables so that other tests work
-    alembic_cfg = Config("etc/test.ini", "app:conduit")
+    alembic_cfg = Config("alembic.ini")
     command.upgrade(alembic_cfg, "head")


### PR DESCRIPTION
Hey @zupo 

After diving more deeply into the approach I had in the other PR, I've decided that it is fundamentally flawed. As is the config directive approach that there's a sketch of in the deferred library that I was planning on extending. I believe that to make those two work we'd have to either monkeypatch alembic or wrap the alembic frontend in our own entrypoint, both of which feel too invasive a change.

This PR represents what I believe is the simpler approach that respects your clear desire for less duplication.

What this does is decouples the alembic and development/production/test ini files, so the alembic configuration is not responsible for database config and the app configuration is not responsible for alembic config.

For users, this means a different invocation of alembic, it gains an `-x ini=etc/development.ini` and the `-c etc/development.ini` becomes `-c etc/alembic.ini`. It would be possible to drop the `-c` entirely if we moved the alembic.ini to the root of the project.

What do you think of this approach?