### PR TITLE
Updare circleci to try both development and production ini files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,14 +78,12 @@ jobs:
       - run:
           name: run dev app
           command: |
-            echo "exit()" >> exit.sh
-            cat exit.sh | pipenv run pshell etc/development.ini SKIP_CHECK_DB_MIGRATED=1
+            pipenv run pshell etc/development.ini SKIP_CHECK_DB_MIGRATED=1 < .circleci/exit.sh
 
-      # - run:
-      #     name: run prod app
-      #     command: |
-      #       echo "exit()" >> exit.sh
-      #       cat exit.sh | DATABASE_URL="postgresql://conduit_dev@localhost/conduit_dev" pipenv run pshell etc/production.ini SKIP_CHECK_DB_MIGRATED=1
+      - run:
+          name: run prod app
+          command: |
+            DATABASE_URL="postgresql://conduit_dev@localhost/conduit_dev" pipenv run pshell etc/production.ini SKIP_CHECK_DB_MIGRATED=1 < .circleci/exit.sh
 
       - run :
           name: run Postman tests

--- a/.circleci/exit.sh
+++ b/.circleci/exit.sh
@@ -1,0 +1,9 @@
+import logging
+
+try:
+    registry.settings['sqlalchemy.engine'].connect()
+except:
+    logging.exception("Could not connect")
+    exit(1)
+
+exit(0)


### PR DESCRIPTION
Previously, only pshell development.ini was tested, not the production
ini file. In addition, as the deferred sqlalchemy library is being used
this would not actually check that the database was connectable. The
on-the-fly exit.sh script has been replaced with a static one that
attempts to connect to the database and returns an appropriate
exit code.

This fixes #27 