### PR TITLE
Update Pipfile.lock flake8-tuple version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ newman
 newman-report.json
 node_modules/
 package-lock.json
+
+# PyCharm
+.idea

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -831,10 +831,10 @@
         },
         "flake8-tuple": {
             "hashes": [
-                "sha256:81b16bc753616d7940275951f69db4cd8c6afafca00eb5767942215c9e455075"
+                "sha256:8d41db2e4a5320ffd29cf78a95f1d7da9f22b47949427a4d7f8391333eec2a15"
             ],
             "index": "pypi",
-            "version": "==0.3.1"
+            "version": "==0.4.0"
         },
         "freezegun": {
             "hashes": [


### PR DESCRIPTION
Update flake8-tuple version because the version 0.3.1 doesn't exist any more on pypi.org.