### PR TITLE
Wait for postgres service to be available

### DIFF
--- a/.docker/devdb.sh
+++ b/.docker/devdb.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-psql "postgresql://$POSTGRES_USER@:5432/$POSTGRES_DB" -v ON_ERROR_STOP=1 <<-EOSQL
+until psql "postgresql://$POSTGRES_USER@:5432" -c '\q'; do
+  >&2 echo "Postgres is unavailable - waiting..."
+  sleep 1
+done
+
+psql -v ON_ERROR_STOP=1 "postgresql://$POSTGRES_USER@:5432" <<-EOSQL
+  DROP DATABASE IF EXISTS conduit_dev;
+  DROP USER IF EXISTS conduit_dev;
   CREATE USER conduit_dev WITH PASSWORD '';
   CREATE DATABASE conduit_dev;
   GRANT ALL PRIVILEGES ON DATABASE conduit_dev TO conduit_dev;

--- a/.docker/testdb.sh
+++ b/.docker/testdb.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 set -e
 
-psql "postgresql://$POSTGRES_USER@:5432/$POSTGRES_DB" -v ON_ERROR_STOP=1 <<-EOSQL
+until psql "postgresql://$POSTGRES_USER@:5432" -c '\q'; do
+  >&2 echo "Postgres is unavailable - waiting..."
+  sleep 1
+done
+
+psql -v ON_ERROR_STOP=1 "postgresql://$POSTGRES_USER@:5432" <<-EOSQL
+  DROP DATABASE IF EXISTS conduit_test;
+  DROP USER IF EXISTS conduit_test;
   CREATE USER conduit_test WITH PASSWORD '';
   CREATE DATABASE conduit_test;
   GRANT ALL PRIVILEGES ON DATABASE conduit_test TO conduit_test;

--- a/.gitignore
+++ b/.gitignore
@@ -123,5 +123,6 @@ newman-report.json
 node_modules/
 package-lock.json
 
-# PyCharm
+# IDEs & code editors
 .idea
+.vscode


### PR DESCRIPTION
- Init DB scripts should wait for the postgres server on slower
machines.
- Ignore IDEs and code editor folders in gitignore.