### PR TITLE
Enforce critical vars must be set

### DIFF
--- a/etc/production.ini
+++ b/etc/production.ini
@@ -19,10 +19,10 @@ pyramid.includes =
 pyramid_heroku.structlog = true
 pyramid_force_https.structlog = true
 
-sqlalchemy.url = ${DATABASE_URL}
+sqlalchemy.url = ${DATABASE_URL:?}
 
 # secrets
-jwt.secret = ${JWT_SECRET}
+jwt.secret = ${JWT_SECRET:?}
 
 ###
 # wsgi server configuration


### PR DESCRIPTION
One of the features of bash's variable expansion system is to enforce that
the value of a variable must be defined using the `{VAR:?}` syntax.
This feature is supported by https://github.com/sayanarijit/expandvars,
used in this app to read the value of config vars from the environment.

Let's use this feature to enforce the same for the env vars in
`etc/production.ini`.