### PR TITLE
Use nix-shell as shebang in the release script

### DIFF
--- a/.heroku/release.sh
+++ b/.heroku/release.sh
@@ -1,3 +1,6 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --argstr type run -i bash /app/shell.nix
+
 set -e
 
 # See https://github.com/niteoweb/pyramid-realworld-example-app/issues/86

--- a/heroku.yml
+++ b/heroku.yml
@@ -5,5 +5,5 @@ run:
   web: gunicorn --paste etc/production.ini --bind :$PORT --workers=3
 release:
   command:
-    - bash .heroku/release.sh
+    - .heroku/release.sh
   image: web


### PR DESCRIPTION
So that we don't have to specify an interpreter to run the script.