### PR TITLE
isort too should be set to line-length of 88

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,6 @@
 [settings]
-force_single_line=true
 atomic=true
 force_alphabetical_sort=true
+force_single_line=true
+line_length=88
 not_skip=__init__.py


### PR DESCRIPTION
Black uses 88 and isort uses 79 by default. They can get caught in a loop
where one tool fixes the output of the other. When we need to set isort to
88 line-length, they agree on how the output should look.