### PR TITLE
Improvement to Makefile

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,0 +1,1 @@
+spawnve

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,9 @@ jobs:
       - run:
           name: Run Linters
           command: |
+            nix-shell --pure --run "poetry run pre-commit install -f --hook-type pre-commit"
             nix-shell --pure --run "poetry run pre-commit install -f --hook-type pre-push"
-            nix-shell --pure --run "make lint"
+            nix-shell --pure --run "make lint all=true"
 
       - run:
           name: run mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,75 +1,82 @@
+minimum_pre_commit_version: 1.17.0
+default_stages: [commit,push]
+repos:
+
 -   repo: local
     hooks:
-    -   id: isort
-        name: isort
-        entry: poetry run isort -rc --atomic src/conduit
-        language: system
-        types: [python]
 
-    -   id: flake8
-        name: Flake8
-        entry: poetry run flake8
-        language: system
-        types: [python]
+        -   id: isort
+            name: isort
+            description: A Python utility that sorts imports alphabetically
+            entry: poetry run isort -rc --atomic
+            language: system
+            types: [python]
 
-    -   id: black
-        name: black
-        entry: poetry run black
-        language: system
-        types: [python]
+        -   id: flake8
+            name: Flake8
+            description: Python Style Guide Enforcement
+            entry: poetry run flake8
+            language: system
+            types: [python]
 
-    -   id: trailing-whitespace
-        name: Trim Trailing Space
-        entry: poetry run trailing-whitespace-fixer
-        language: system
-        types: [non-executable, file, text]
-        exclude_types: [svg]
+        -   id: black
+            name: Black
+            description: Uncompromising Python code formatter
+            entry: poetry run black
+            language: system
+            types: [python]
 
-    -   id: end-of-file-fixer
-        name: Fix End of Files
-        description: Ensures that a file is either empty, or ends with one newline.
-        entry: poetry run end-of-file-fixer
-        language: system
-        types: [non-executable, file, text]
-        exclude_types: [svg]
+        -   id: trailing-whitespace
+            name: Trailing Whitespace
+            entry: poetry run trailing-whitespace-fixer
+            language: system
+            types: [non-executable, file, text]
+            exclude_types: [svg]
 
-    -   id: check-merge-conflict
-        name: Check for merge conflicts
-        description: Check for files that contain merge conflict strings.
-        entry: poetry run check-merge-conflict
-        language: system
-        stages: [push]
+        -   id: end-of-file-fixer
+            name: End of Files
+            description: Ensures that a file is either empty, or ends with one newline.
+            entry: poetry run end-of-file-fixer
+            language: system
+            types: [non-executable, file, text]
+            exclude_types: [svg]
 
-    -   id: codespell
-        name: Check Spelling
-        description: Checks for common misspellings in text files.
-        entry: poetry run codespell --ignore-words .aspell.en.pws
-        language: system
-        types: [non-executable, file, text]
-        exclude_types: [svg]
-        exclude: 'elm\.js'
-        stages: [push]
+        -   id: check-merge-conflict
+            name: Merge Conflicts
+            description: Check for files that contain merge conflict strings.
+            entry: poetry run check-merge-conflict
+            language: system
+            types: [non-executable, file, text]
+            exclude_types: [svg]
 
-    -   id: debug-statements
-        name: Check Debug Statements Absent (Python)
-        description: Checks that debug statements (pdb, ipdb, pudb) are not imported on commit.
-        entry: poetry run debug-statement-hook
-        language: system
-        types: [python]
-        stages: [push]
+        -   id: codespell
+            name: Spelling
+            description: Checks for common misspellings in text files.
+            entry: poetry run codespell --ignore-words .aspell.en.pws
+            language: system
+            types: [non-executable, file, text]
+            exclude: 'elm\.js'
+            exclude_types: [svg]
 
-    -   id: no-orm-alembic
-        name: Check that ORM is not used in alembic migrations
-        args: []
-        entry: bash -c 'grep -ir "from sqlalchemy import orm" src/conduit/migrations/versions; test $? -eq 1'
-        files: '(^.*src/conduit/migrations/versions/.*)'
-        language: system
-        stages: [commit]
+        -   id: debug-statements
+            name: Debug Statements
+            description: Checks that debug statements (pdb, ipdb, pudb) are not imported on commit.
+            entry: poetry run debug-statement-hook
+            language: system
+            types: [python]
+            stages: [push]
 
-    -   id: bandit
-        name: Check for common security issues
-        args: []
-        entry: poetry run bandit -r src/conduit/ --skip B608 -x *tests*,src/conduit/scripts/populate.py
-        language: system
-        pass_filenames: false
-        stages: [push]
+        -   id: no-orm-alembic
+            name: No ORM in Alembic
+            description: Check that ORM is not used in Alembic migrations
+            entry: bash -c 'grep -ir "from sqlalchemy import orm" "$@"; test $? -eq 1' --
+            language: system
+            files: ^src/conduit/migrations/versions/.*
+            types: [python]
+
+        -   id: bandit
+            name: Bandit
+            description: Check for common security issues
+            entry: poetry run bandit -ii --silent --config bandit.yaml --exclude *tests*
+            language: system
+            types: [python]

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,392 @@
+### This config may optionally select a subset of tests to run or skip by
+### filling out the 'tests' and 'skips' lists given below. If no tests are
+### specified for inclusion then it is assumed all tests are desired. The skips
+### set will remove specific tests from the include set. This can be controlled
+### using the -t/-s CLI options. Note that the same test ID should not appear
+### in both 'tests' and 'skips', this would be nonsensical and is detected by
+### Bandit at runtime.
+
+# Available tests:
+# B101 : assert_used
+# B102 : exec_used
+# B103 : set_bad_file_permissions
+# B104 : hardcoded_bind_all_interfaces
+# B105 : hardcoded_password_string
+# B106 : hardcoded_password_funcarg
+# B107 : hardcoded_password_default
+# B108 : hardcoded_tmp_directory
+# B110 : try_except_pass
+# B112 : try_except_continue
+# B201 : flask_debug_true
+# B301 : pickle
+# B302 : marshal
+# B303 : md5
+# B304 : ciphers
+# B305 : cipher_modes
+# B306 : mktemp_q
+# B307 : eval
+# B308 : mark_safe
+# B309 : httpsconnection
+# B310 : urllib_urlopen
+# B311 : random
+# B312 : telnetlib
+# B313 : xml_bad_cElementTree
+# B314 : xml_bad_ElementTree
+# B315 : xml_bad_expatreader
+# B316 : xml_bad_expatbuilder
+# B317 : xml_bad_sax
+# B318 : xml_bad_minidom
+# B319 : xml_bad_pulldom
+# B320 : xml_bad_etree
+# B321 : ftplib
+# B322 : input
+# B323 : unverified_context
+# B324 : hashlib_new_insecure_functions
+# B325 : tempnam
+# B401 : import_telnetlib
+# B402 : import_ftplib
+# B403 : import_pickle
+# B404 : import_subprocess
+# B405 : import_xml_etree
+# B406 : import_xml_sax
+# B407 : import_xml_expat
+# B408 : import_xml_minidom
+# B409 : import_xml_pulldom
+# B410 : import_lxml
+# B411 : import_xmlrpclib
+# B412 : import_httpoxy
+# B413 : import_pycrypto
+# B501 : request_with_no_cert_validation
+# B502 : ssl_with_bad_version
+# B503 : ssl_with_bad_defaults
+# B504 : ssl_with_no_version
+# B505 : weak_cryptographic_key
+# B506 : yaml_load
+# B507 : ssh_no_host_key_verification
+# B601 : paramiko_calls
+# B602 : subprocess_popen_with_shell_equals_true
+# B603 : subprocess_without_shell_equals_true
+# B604 : any_other_function_with_shell_equals_true
+# B605 : start_process_with_a_shell
+# B606 : start_process_with_no_shell
+# B607 : start_process_with_partial_path
+# B608 : hardcoded_sql_expressions
+# B609 : linux_commands_wildcard_injection
+# B610 : django_extra_used
+# B611 : django_rawsql_used
+# B701 : jinja2_autoescape_false
+# B702 : use_of_mako_templates
+# B703 : django_mark_safe
+
+# (optional) list included test IDs here, eg '[B101, B406]':
+tests:
+
+# (optional) list skipped test IDs here, eg '[B101, B406]':
+skips: ['B608']
+
+### (optional) plugin settings - some test plugins require configuration data
+### that may be given here, per-plugin. All bandit test plugins have a built in
+### set of sensible defaults and these will be used if no configuration is
+### provided. It is not necessary to provide settings for every (or any) plugin
+### if the defaults are acceptable.
+
+any_other_function_with_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+hardcoded_tmp_directory:
+  tmp_dirs:
+  - /tmp
+  - /var/tmp
+  - /dev/shm
+linux_commands_wildcard_injection:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+ssl_with_bad_defaults:
+  bad_protocol_versions:
+  - PROTOCOL_SSLv2
+  - SSLv2_METHOD
+  - SSLv23_METHOD
+  - PROTOCOL_SSLv3
+  - PROTOCOL_TLSv1
+  - SSLv3_METHOD
+  - TLSv1_METHOD
+ssl_with_bad_version:
+  bad_protocol_versions:
+  - PROTOCOL_SSLv2
+  - SSLv2_METHOD
+  - SSLv23_METHOD
+  - PROTOCOL_SSLv3
+  - PROTOCOL_TLSv1
+  - SSLv3_METHOD
+  - TLSv1_METHOD
+start_process_with_a_shell:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+start_process_with_no_shell:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+start_process_with_partial_path:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+subprocess_popen_with_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+subprocess_without_shell_equals_true:
+  no_shell:
+  - os.execl
+  - os.execle
+  - os.execlp
+  - os.execlpe
+  - os.execv
+  - os.execve
+  - os.execvp
+  - os.execvpe
+  - os.spawnl
+  - os.spawnle
+  - os.spawnlp
+  - os.spawnlpe
+  - os.spawnv
+  - os.spawnve
+  - os.spawnvp
+  - os.spawnvpe
+  - os.startfile
+  shell:
+  - os.system
+  - os.popen
+  - os.popen2
+  - os.popen3
+  - os.popen4
+  - popen2.popen2
+  - popen2.popen3
+  - popen2.popen4
+  - popen2.Popen3
+  - popen2.Popen4
+  - commands.getoutput
+  - commands.getstatusoutput
+  subprocess:
+  - subprocess.Popen
+  - subprocess.call
+  - subprocess.check_call
+  - subprocess.check_output
+  - subprocess.run
+try_except_continue:
+  check_typed_exception: true
+try_except_pass:
+  check_typed_exception: true
+weak_cryptographic_key:
+  weak_key_size_dsa_high: 1024
+  weak_key_size_dsa_medium: 2048
+  weak_key_size_ec_high: 160
+  weak_key_size_ec_medium: 224
+  weak_key_size_rsa_high: 1024
+  weak_key_size_rsa_medium: 2048


### PR DESCRIPTION
Cherry-picked from @niteoweb projects:

1. Add a one-second delay before reinstalling the whole poetry environment, so
   it's possible to quickly `ctrl-C` it.
2. Add `make pgcli` command.
3. Append `--reload` to `make run` command.
4. Way smarter selection of which files should be linted: only those that were
   modified. This *really* increases development speed as auto-linting on git
   commit is much faster. That said, CI still runs lints on all files.
5. Don't purge mypy cache on every run. Again, to speed up development.
6. `make format` is not needed as `black` is run as part of pre-commit checks.