### PR TITLE
Use `poetry update --lock`

### DIFF
--- a/.github/workflows/update.sh
+++ b/.github/workflows/update.sh
@@ -9,7 +9,7 @@ git fetch --unshallow
 niv update
 
 # Update Python packages
-poetry update
+poetry update --lock
 
 # Only continue if there are any changes
 if ! git diff-index --quiet HEAD; then


### PR DESCRIPTION
With `--lock`, poetry will only update the `poetry.lock` file without
installing the packages. This will make the workflow run faster.